### PR TITLE
chore: upgrade Calcit to 0.13.16

### DIFF
--- a/calcit.cirru
+++ b/calcit.cirru
@@ -5,14 +5,14 @@
       :modules $ [] |respo.calcit/ |lilac/ |memof/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
       :type-slots $ {}
   :files $ {}
-    |app.comp.container $ %{} :FileEntry
+    |app.comp.container $ %{} 'FileEntry
       :defs $ {}
-        |comp-container $ %{} :CodeEntry (:doc |)
+        |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-container (reel)
               let
-                  store $ :store reel
-                  states $ :states store
+                  store $ unsafe-coerce (get reel :store) 'app.types/Store
+                  states $ &struct:get store :states
                 div
                   {} $ :style
                     merge ui/global ui/fullscreen ui/row $ {} (:justify-content :center)
@@ -27,17 +27,18 @@
                       {} (:class-name |markdown-body)
                         :highlight $ fn (code lang)
                           if (= lang |cirru) (color/generate code)
-                            .-value $ .!highlight hljs code
-                              js-object $ :language lang
+                            .-value $ unsafe-coerce
+                              .!highlight hljs code $ js-object (:language lang)
+                              , js-object
                   when dev? $ comp-reel (>> states :reel) reel ({})
           :examples $ []
           :schema $ :: 'Dynamic
-        |slurp $ %{} :CodeEntry (:doc |)
+        |slurp $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro slurp (path) (read-file path)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require
             respo-ui.core :refer $ hsl
@@ -50,9 +51,9 @@
             respo-md.comp.md :refer $ comp-md-block
             |highlight.js :default hljs
             |cirru-color :as color
-    |app.config $ %{} :FileEntry
+    |app.config $ %{} 'FileEntry
       :defs $ {}
-        |cdn? $ %{} :CodeEntry (:doc |)
+        |cdn? $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def cdn? $ cond
                 exists? js/window
@@ -61,32 +62,35 @@
               :else false
           :examples $ []
           :schema $ :: 'Dynamic
-        |dev? $ %{} :CodeEntry (:doc |)
+        |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def dev? $ = |dev (get-env |mode |release)
+            def dev? $ = |dev
+              option:unwrap-or (get-env |mode) |release
           :examples $ []
-          :schema $ :: 'Dynamic
-        |site $ %{} :CodeEntry (:doc |)
+          :schema $ :: 'Bool
+        |site $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def site $ {} (:dev-ui |http://localhost:8100/main-fonts.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main-fonts.css) (:cdn-url |http://cdn.tiye.me/cumulo-org/) (:title "|Cumulo Home Page") (:icon |http://cdn.tiye.me/logo/respo.png) (:storage-key |cumulo.org)
+            def site $ %{} app.types/SiteConfig (:dev-ui |http://localhost:8100/main-fonts.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main-fonts.css) (:cdn-url |http://cdn.tiye.me/cumulo-org/) (:title "|Cumulo Home Page") (:icon |http://cdn.tiye.me/logo/respo.png) (:storage-key |cumulo.org)
           :examples $ []
-          :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
-        :code $ quote (ns app.config)
-    |app.main $ %{} :FileEntry
+          :schema $ :: 'app.types/SiteConfig
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.config $ :require
+            app.types :refer $ SiteConfig
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |*reel $ %{} :CodeEntry (:doc |)
+        |*reel $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *reel $ -> reel-schema/reel (assoc :base schema/store) (assoc :store schema/store)
           :examples $ []
           :schema $ :: 'Dynamic
-        |dispatch! $ %{} :CodeEntry (:doc |)
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op) (; println |Dispatch: op)
               reset! *reel $ reel-updater updater @*reel op
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -96,46 +100,47 @@
               render-app! render!
               add-watch *reel :changes $ fn (r p) (render-app! render!)
               listen-devtools! |k dispatch!
-              .!addEventListener js/window |beforeunload persist-storage!
+              js/window.addEventListener |beforeunload persist-storage!
               js/setInterval persist-storage! $ * 1000 60
               let
-                  raw $ js/localStorage.getItem (:storage-key config/site)
-                when (some? raw)
-                  dispatch! $ :: :hydrate-storage (parse-cirru-edn raw)
+                  raw $ js/localStorage.getItem (&struct:get config/site :storage-key)
+                when (js-present? raw)
+                  dispatch! $ :: :hydrate-storage
+                    parse-cirru-edn $ unsafe-coerce raw String
               println "|App started."
           :examples $ []
           :schema $ :: 'Dynamic
-        |mount-target $ %{} :CodeEntry (:doc |)
+        |mount-target $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
           :schema $ :: 'Dynamic
-        |persist-storage! $ %{} :CodeEntry (:doc |)
+        |persist-storage! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn persist-storage! (? e)
-              js/localStorage.setItem (:storage-key config/site)
-                format-cirru-edn $ :store @*reel
+              js/localStorage.setItem (&struct:get config/site :storage-key)
+                format-cirru-edn $ &struct:get @*reel :store
           :examples $ []
           :schema $ :: 'Dynamic
-        |reload! $ %{} :CodeEntry (:doc |)
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () (clear-cache!)
               reset! *reel $ refresh-reel @*reel schema/store updater
               println "|Code updated."
           :examples $ []
           :schema $ :: 'Dynamic
-        |render-app! $ %{} :CodeEntry (:doc |)
+        |render-app! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-app! (renderer)
               renderer mount-target (comp-container @*reel) dispatch!
           :examples $ []
           :schema $ :: 'Dynamic
-        |ssr? $ %{} :CodeEntry (:doc |)
+        |ssr? $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def ssr? $ some? (js/document.querySelector |meta.respo-ssr)
+            def ssr? $ js-present? (js/document.querySelector |meta.respo-ssr)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require
             respo.core :refer $ render! clear-cache! realize-ssr!
@@ -150,9 +155,9 @@
             |highlight.js :default hljs
             |highlight.js/lib/languages/clojure :default clojure-lang
             |highlight.js/lib/languages/bash :default bash-lang
-    |app.page $ %{} :FileEntry
+    |app.page $ %{} 'FileEntry
       :defs $ {}
-        |base-info $ %{} :CodeEntry (:doc |)
+        |base-info $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def base-info $ {}
               :title $ :title config/site
@@ -161,7 +166,7 @@
               :inline-html nil
           :examples $ []
           :schema $ :: 'Dynamic
-        |dev-page $ %{} :CodeEntry (:doc |)
+        |dev-page $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dev-page () $ make-page |
               merge base-info $ {}
@@ -170,7 +175,7 @@
                 :inline-styles $ [] (slurp |entry/github-gist.css) (slurp |node_modules/github-markdown-css/github-markdown.css)
           :examples $ []
           :schema $ :: 'Dynamic
-        |main! $ %{} :CodeEntry (:doc |)
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -179,7 +184,7 @@
                 spit |dist/index.html $ prod-page
           :examples $ []
           :schema $ :: 'Dynamic
-        |prod-page $ %{} :CodeEntry (:doc |)
+        |prod-page $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn prod-page () $ let
                 reel $ -> reel-schema/reel (assoc :base schema/store) (assoc :store schema/store)
@@ -195,7 +200,7 @@
                   :inline-styles $ [] (slurp |entry/github-gist.css) (slurp |node_modules/github-markdown-css/github-markdown.css) (slurp |./entry/main.css)
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.page $ :require
             respo.render.html :refer $ make-string
@@ -207,20 +212,36 @@
             app.config :as config
             cumulo-util.build :refer $ get-ip!
             clojure.core.strint :refer $ <<
-    |app.schema $ %{} :FileEntry
+    |app.schema $ %{} 'FileEntry
       :defs $ {}
-        |store $ %{} :CodeEntry (:doc |)
+        |store $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def store $ {}
+            def store $ %{} app.types/Store
               :states $ {}
               :content |
           :examples $ []
-          :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
-        :code $ quote (ns app.schema)
-    |app.updater $ %{} :FileEntry
+          :schema $ :: 'app.types/Store
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote
+          ns app.schema $ :require
+            app.types :refer $ Store
+    |app.types $ %{} 'FileEntry
       :defs $ {}
-        |updater $ %{} :CodeEntry (:doc |)
+        |SiteConfig $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct SiteConfig (:dev-ui 'String) (:release-ui 'String) (:cdn-url 'String) (:title 'String) (:icon 'String) (:storage-key 'String)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |Store $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct Store (:states 'Map) (:content 'String)
+          :examples $ []
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
+        :code $ quote (ns app.types)
+    |app.updater $ %{} 'FileEntry
+      :defs $ {}
+        |updater $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn updater (store op op-id op-time)
               tag-match op
@@ -230,7 +251,7 @@
                 _ $ do (eprintln "|Unknown op:" op) store
           :examples $ []
           :schema $ :: 'Dynamic
-      :ns $ %{} :NsEntry (:doc |)
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require
             respo.cursor :refer $ update-states

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,8 +1,8 @@
 
-{} (:calcit-version |0.12.59)
-  :dependencies $ {} (|Respo/reel.calcit |0.6.4)
-    |Respo/respo-markdown.calcit |0.4.20
-    |Respo/respo-ui.calcit |0.7.0
-    |Respo/respo.calcit |0.16.60
-    |calcit-lang/lilac |0.5.1
+{} (:calcit-version |0.13.16)
+  :dependencies $ {} (|Respo/reel.calcit |0.6.6)
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-ui.calcit |0.7.7
+    |Respo/respo.calcit |0.16.70
+    |calcit-lang/lilac |0.5.2
     |calcit-lang/memof |0.0.26

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vite": "^7.3.5"
   },
   "dependencies": {
-    "@calcit/procs": "^0.12.59",
+    "@calcit/procs": "^0.13.16",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.1",
     "dayjs": "^1.11.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.59":
-  version: 0.12.59
-  resolution: "@calcit/procs@npm:0.12.59"
+"@calcit/procs@npm:^0.13.16":
+  version: 0.13.16
+  resolution: "@calcit/procs@npm:0.13.16"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/dd5e1b6f6481c06c92faebc9de8ca8a0938938fbb158e9a79c76bbaaf1a42e712202555d39f209e24abb25eca5e7035869ddb0e82a3c6304d1d6d4576c323c64
+  checksum: 10c0/b7662b272ceb218ef3455a668b32567af13a75dcb98b9bbcd4535d95fad4afa82937204d72c08fa68d66356dec5b70c9047a7b63618fe2369005a0186799bec1
   languageName: node
   linkType: hard
 
@@ -438,7 +438,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "calcit-workflow@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.59"
+    "@calcit/procs": "npm:^0.13.16"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.1"


### PR DESCRIPTION
## Summary
- upgrade calcit-version to 0.13.16, `@calcit/procs` to ^0.13.16
- bump respo.calcit to 0.16.70, lilac to 0.5.2, reel/respo-ui/respo-markdown to latest
- strengthen types: define `Store`/`SiteConfig` structs, fix get-env/js-present?/FFI access

## Verification
- `cr calcit.cirru --check-only` passes
- `cr calcit.cirru js` and vite build succeed